### PR TITLE
Add environment for JRuby

### DIFF
--- a/envs/jruby/README.md
+++ b/envs/jruby/README.md
@@ -1,0 +1,3 @@
+# JRuby
+
+Environment to build and run [JRuby](https://www.jruby.org/).

--- a/envs/jruby/shell.nix
+++ b/envs/jruby/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+with stdenv;
+with stdenv.lib;
+mkShell {
+  name = "jruby-shell";
+
+  buildInputs = [ jruby cacert ];
+
+  # Likely want a CA file; so lets add one.
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  # Make UTF8 the default as it's more sane
+  LANG = "en_US.UTF-8";
+  shellHook = ''
+      # https://nixos.org/nixpkgs/manual/#locales
+      export optionalString isLinux LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
+      # JRuby wants to install Gem's in the nix-store which is read-only
+      # set GEM_HOME to make it a writable directory
+    	export GEM_HOME=$(${jruby}/bin/ruby -e 'puts Gem.user_dir')
+      export GEM_PATH=$GEM_HOME
+      # Add the GEM binary files to the path
+      export PATH=$GEM_HOME/bin:$PATH
+      '';
+}

--- a/envs/jruby/shell.nix
+++ b/envs/jruby/shell.nix
@@ -12,9 +12,10 @@ mkShell {
 
   # Make UTF8 the default as it's more sane
   LANG = "en_US.UTF-8";
+  # https://nixos.org/nixpkgs/manual/#locales
+  LOCALE_ARCHIVE =
+    optionalString isLinux "${glibcLocales}/lib/locale/locale-archive";
   shellHook = ''
-      # https://nixos.org/nixpkgs/manual/#locales
-      export optionalString isLinux LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
       # JRuby wants to install Gem's in the nix-store which is read-only
       # set GEM_HOME to make it a writable directory
     	export GEM_HOME=$(${jruby}/bin/ruby -e 'puts Gem.user_dir')


### PR DESCRIPTION
JRuby unlike **ruby** in _nixpkgs_ does not apply a patch to change the default gem installation directory.
As a result whomever uses it must specify _GEM_HOME_.

I consider that _gotcha_ enough to warrant having it in this repo as non-trivial.