### PR TITLE
arduino: add ncurses dependency to targetPkgs

### DIFF
--- a/envs/arduino/shell.nix
+++ b/envs/arduino/shell.nix
@@ -3,6 +3,7 @@
 (pkgs.buildFHSUserEnv {
   name = "arduino-env";
   targetPkgs = pkgs: with pkgs; [
+    ncurses
     arduino
     zlib
     (python3.withPackages(ps: [


### PR DESCRIPTION
Without ncurses, this shell will fail with "bash: tput: command not found"