### PR TITLE
envs/yocto: add lz4

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -19,6 +19,7 @@ let
         hostname
         kconfig-frontends
         lzma
+        lz4
         ncurses
         patch
         perl


### PR DESCRIPTION
Found that this was needed while using the `bitbake-layers` tool.