### PR TITLE
openwrt: replace removed alias utillinux -> util-linux

### DIFF
--- a/envs/openwrt/shell.nix
+++ b/envs/openwrt/shell.nix
@@ -19,7 +19,7 @@ let
       gnumake
       gcc
       unzip
-      utillinux
+      util-linux
       python2
       python3.6
       rsync


### PR DESCRIPTION
Fixes build error in `master` together with #34