### PR TITLE
yocto: replace removed alias lzma -> xz

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -18,7 +18,7 @@ let
         gnumake
         hostname
         kconfig-frontends
-        lzma
+        xz
         ncurses
         patch
         perl


### PR DESCRIPTION
Fixes build error in `master` together with #33