### PR TITLE
Fixes to the Yocto environment

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -4,6 +4,7 @@ let
   fhs = pkgs.buildFHSUserEnvBubblewrap {
     name = "yocto-fhs";
     targetPkgs = pkgs: (with pkgs; [
+        attr
         bc
         binutils
         bzip2
@@ -18,6 +19,7 @@ let
         gnumake
         hostname
         kconfig-frontends
+        libxcrypt
         lz4
         ncurses
         patch
@@ -29,6 +31,8 @@ let
         wget
         which
         xz
+        zlib
+        zstd
       ]);
     multiPkgs = null;
     extraOutputsToInstall = [ "dev" ];

--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -71,6 +71,11 @@ let
         '';
       in
       ''
+        # buildFHSUserEnvBubblewrap configures ld.so.conf while buildFHSUserEnv additionally sets the LD_LIBRARY_PATH.
+        # This is redundant, and incorrectly overrides the RPATH of yocto-built binaries causing the dynamic loader
+        # to load libraries from the host system that they were not built against, instead of those from yocto.
+        unset LD_LIBRARY_PATH
+
         # By default gcc-wrapper will compile executables that specify a dynamic loader that will ignore the FHS
         # ld-config causing unexpected libraries to be loaded when when the executable is run.
         export NIX_DYNAMIC_LINKER_${pkgs.stdenv.cc.suffixSalt}="/lib/ld-linux-x86-64.so.2"

--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -47,6 +47,9 @@ let
         exportVars = [
           "LOCALE_ARCHIVE"
           "NIX_CC_WRAPPER_TARGET_HOST_${pkgs.stdenv.cc.suffixSalt}"
+          "NIX_CFLAGS_COMPILE"
+          "NIX_CFLAGS_LINK"
+          "NIX_LDFLAGS"
         ];
 
         exports =

--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -50,6 +50,7 @@ let
           "NIX_CFLAGS_COMPILE"
           "NIX_CFLAGS_LINK"
           "NIX_LDFLAGS"
+          "NIX_DYNAMIC_LINKER_${pkgs.stdenv.cc.suffixSalt}"
         ];
 
         exports =
@@ -70,6 +71,10 @@ let
         '';
       in
       ''
+        # By default gcc-wrapper will compile executables that specify a dynamic loader that will ignore the FHS
+        # ld-config causing unexpected libraries to be loaded when when the executable is run.
+        export NIX_DYNAMIC_LINKER_${pkgs.stdenv.cc.suffixSalt}="/lib/ld-linux-x86-64.so.2"
+
         # These are set by buildFHSUserEnvBubblewrap
         export BB_ENV_PASSTHROUGH_ADDITIONS="${lib.strings.concatStringsSep " " passthroughVars}"
 

--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -19,7 +19,6 @@ let
         hostname
         kconfig-frontends
         lz4
-        xz
         ncurses
         patch
         perl
@@ -29,6 +28,7 @@ let
         util-linux
         wget
         which
+        xz
       ]);
     multiPkgs = null;
     extraOutputsToInstall = [ "dev" ];


### PR DESCRIPTION
This branch fixes various issues with the Yocto environment.

With these fixes applied, the full builds of [yocto/poky](https://www.yoctoproject.org/software-item/poky/) adn [OE4T/meta-tegra](https://github.com/OE4T/meta-tegra/) both build successfully.