### PR TITLE
openwrt: prevent libtool from picking up host libs

### DIFF
--- a/envs/openwrt/shell.nix
+++ b/envs/openwrt/shell.nix
@@ -44,6 +44,8 @@ let
     extraOutputsToInstall = [ "dev" ];
     profile = ''
       export hardeningDisable=all
+      # prevent libtool from picking up host libs
+      unset LD_LIBRARY_PATH
     '';
   };
 in fhs.env


### PR DESCRIPTION
this fixes the error [mentioned on the wiki](https://nixos.wiki/wiki/OpenWRT#mw-content-text):

    /usr/lib/libuuid.so: file not recognized: file format not recognized