### PR TITLE
add python and libxcrypt-legacy to xilinx-vitis environment

### DIFF
--- a/envs/xilinx-vitis/shell.nix
+++ b/envs/xilinx-vitis/shell.nix
@@ -28,6 +28,8 @@
     glib
     gtk2
     gtk3
+    libxcrypt-legacy # required for Vivado
+    python3
 
     # to compile some xilinx examples
     opencl-clhpp


### PR DESCRIPTION
These where missing to use a vitis 2023.x environment. Fixes #49.