### PR TITLE
add openwrt-ci (fhs without .env)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,8 @@
   home-assistant = import ./envs/home-assistant/shell.nix { inherit pkgs; };
   nannou = import ./envs/nannou/shell.nix { inherit pkgs; };
   jruby = import ./envs/jruby/shell.nix { inherit pkgs; };
-  openwrt = import ./envs/openwrt/shell.nix { inherit pkgs; };
+  openwrt = (import ./envs/openwrt/shell.nix { inherit pkgs; }).env;
+  openwrt-ci = import ./envs/openwrt/shell.nix { inherit pkgs; };
   phoronix-test-suite = import ./envs/phoronix-test-suite/shell.nix { inherit pkgs; };
   spec-benchmark = import ./envs/spec-benchmark/shell.nix { inherit pkgs; };
   yocto = import ./envs/yocto/shell.nix { inherit pkgs; };

--- a/envs/openwrt/shell.nix
+++ b/envs/openwrt/shell.nix
@@ -46,4 +46,4 @@ let
       export hardeningDisable=all
     '';
   };
-in fhs.env
+in fhs


### PR DESCRIPTION
This change allows to use the openwrt environment as a standalone fhs environment within a CI.

For example:
```
name: Build OpenWrt images

on:
  repository_dispatch:
  workflow_dispatch:
  push:
    tags:
      - "v*"

jobs:
  build-openwrt-images:
    runs-on: ubuntu-22.04
    defaults:
      run:
        shell: nix develop .#openwrt-ci --command bash {0}

    steps:
      - name: Checkout
        uses: actions/checkout@v3

      - uses: cachix/install-nix-action@v22
        with:
          nix_path: nixpkgs=channel:nixos-unstable

      - name: prepare source
        run: |
          echo "hello from within the nix devShell"
```