### PR TITLE
add infinitime environment

### DIFF
--- a/envs/infinitime/README.md
+++ b/envs/infinitime/README.md
@@ -1,0 +1,21 @@
+# InfiniTime
+
+Build environment for [InfiniTime](https://github.com/InfiniTimeOrg/InfiniTime/issues?q=is%3Aissue+is%3Aopen+gcc).
+
+Note: Uses `unfree` package `nrf5-sdk`!
+
+## Building the Project
+
+Build instructions:
+
+```
+$ nix-shell
+$ mkdir build
+$ cd build
+$ cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=/usr -DNRF5_SDK_PATH=/usr/share/nRF5_SDK -DCMAKE_BUILD_TYPE=Release ..
+$ make -j6 pinetime-app
+```
+
+Note that the `ARM_NONE_EABI_TOOLCHAIN_PATH` is just `/usr` as everything is linked there.
+
+Further build instructions: https://github.com/InfiniTimeOrg/InfiniTime/blob/main/doc/buildAndProgram.md

--- a/envs/infinitime/shell.nix
+++ b/envs/infinitime/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> {
+    config.allowUnfree = true;
+}, extraPkgs ? []
+}:
+
+(pkgs.buildFHSUserEnv {
+  name = "infinitime-env";
+  targetPkgs = pkgs: with pkgs; [
+    gcc-arm-embedded-10
+    nrf5-sdk
+    zlib
+    cmake
+    gcc10
+    (python3.withPackages(python: [
+      python.cbor
+      python.intelhex
+      python.click
+      python.cryptography
+      python.imgtool
+      
+    ]))
+    nodePackages.lv_font_conv
+  ] ++ extraPkgs;
+  multiPkgs = null;
+}).env


### PR DESCRIPTION
Most notably are the use of `gcc10` and `gcc-arm-embedded-10` as well as the `nonfree` package `nrf5-sdk`.

I configured this nix-shell environment to allow nonfree-packages as it is required for infinitime but one could argue that this is silently allowing unfree packages which might be unwanted / unexpected by the user. Alternatively I can add a more elaborate note in the readme instead.
