### PR TITLE
yocto: add missing setuptools, used by devtool.

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -37,7 +37,7 @@ let
       (ncurses'.override { unicodeSupport = false; })
       patch
       perl
-      python3
+      (python3.withPackages (ps: [ ps.setuptools ]))
       rpcsvc-proto
       unzip
       util-linux


### PR DESCRIPTION
`devtool add` requires `setuptools`. 