### PR TITLE
update README to include information on how to modify buildFHSUserEnv-based environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ in (phoronix.overrideAttrs (old: {
 }))
 ```
 
+To provide additional packages to buildFHSUserEnv-based environments you can use the `extraPkgs` attribute and `import` 
+the shell file directly:
+
+```nix
+{pkgs ? import <nixpkgs> {}}: 
+let
+  yoctoEnv = ((builtins.fetchTarball {
+      url = "https://github.com/nix-community/nix-environments/archive/master.tar.gz";
+    })
+    + "/envs/yocto/shell.nix");
+in
+  (import yoctoEnv) {
+    inherit pkgs;
+    extraPkgs = [pkgs.hello];
+  }
+```
+
 ### Nix Flakes
 
 Nix-environments are also available as Flake outputs. Flakes are an [experimental new way to handle Nix expressions](https://nixos.wiki/wiki/Flakes).


### PR DESCRIPTION
Currently, the readme only provides an example on how to override attributes for non-buildFHSUserEnv-based environments. I needed to add a few additional packages to my yocto environment and struggled to find any information on how override buildFHSUserEnv-derivations in general until I came up with the solution in this PR.

I don't know whether this is the intended to use the extraPkgs attribute, so feel free to correct me if there is a better way to use it and I'll happily update this PR. 