### PR TITLE
Use python 3.12 for Home Assistant

### DIFF
--- a/envs/home-assistant/shell.nix
+++ b/envs/home-assistant/shell.nix
@@ -7,8 +7,8 @@ pkgs.mkShell {
     bashInteractive
     pkg-config
     autoreconfHook
-    python3.pkgs.setuptools
-    python3
+    python312.pkgs.setuptools
+    python312
     libxslt
     doxygen
     graphviz


### PR DESCRIPTION
Python 3.12 is required now.