### PR TITLE
yocto: add pyaml library.

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -37,7 +37,7 @@ let
       (ncurses'.override { unicodeSupport = false; })
       patch
       perl
-      (python3.withPackages (ps: [ ps.setuptools ]))
+      (python3.withPackages (ps: [ ps.setuptools ps.pyaml ]))
       rpcsvc-proto
       unzip
       util-linux


### PR DESCRIPTION
Recent _scarthgap_ `meta-xilinx-core` depends on  `pyaml`. 

```
[alain@desktop:~/projects/stt/its2-yocto/build]$ devtool status
NOTE: Starting bitbake server...
Traceback (most recent call last):
  File "/home/alain/projects/stt/its2-yocto/meta/poky/scripts/devtool", line 350, in <module>
    ret = main()
  File "/home/alain/projects/stt/its2-yocto/meta/poky/scripts/devtool", line 305, in main
    scriptutils.load_plugins(logger, plugins, pluginpath)
  File "/home/alain/projects/stt/its2-yocto/meta/poky/scripts/lib/scriptutils.py", line 96, in load_plugins
    plugin = load_plugin(name)
  File "/home/alain/projects/stt/its2-yocto/meta/poky/scripts/lib/scriptutils.py", line 85, in load_plugin
    spec.loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/alain/projects/stt/its2-yocto/meta/meta-xilinx/meta-xilinx-core/lib/devtool/boot-jtag.py", line 14, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

```
[alain@desktop:~/projects/stt/its2-yocto/build]$ git submodule status  ../meta/meta-xilinx
 62523c2bc42b6b0c5d795373e5110a5c07ed52d8 ../meta/meta-xilinx (xlnx-rel-v2023.1-1083-g62523c2b)
```
