### PR TITLE
envs/infinitime: use mkshell instead of buildFHS

### DIFF
--- a/envs/infinitime/README.md
+++ b/envs/infinitime/README.md
@@ -19,3 +19,5 @@ $ make -j6 pinetime-app
 Note that the `ARM_NONE_EABI_TOOLCHAIN_PATH` is just `/usr` as everything is linked there.
 
 Further build instructions: https://github.com/InfiniTimeOrg/InfiniTime/blob/main/doc/buildAndProgram.md
+
+This `shell.nix` works with `direnv`.

--- a/envs/infinitime/shell.nix
+++ b/envs/infinitime/shell.nix
@@ -1,24 +1,23 @@
-{ pkgs ? import <nixpkgs> {
-    config.allowUnfree = true;
-}, extraPkgs ? []
+{
+  pkgs ? import <nixpkgs> { config.allowUnfree = true; },
+  extraPkgs ? []
 }:
-
-(pkgs.buildFHSUserEnv {
-  name = "infinitime-env";
-  targetPkgs = pkgs: with pkgs; [
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
     gcc-arm-embedded-10
     nrf5-sdk
     zlib
     cmake
     gcc10
+    adafruit-nrfutil
     (python3.withPackages(python: [
       python.cbor
       python.intelhex
       python.click
       python.cryptography
       python.imgtool
+      python.pillow
     ]))
     nodePackages.lv_font_conv
   ] ++ extraPkgs;
-  multiPkgs = null;
-}).env
+}


### PR DESCRIPTION
buildFHSUserEnv has some drawbacks so it is preferrable if possible to use a pkgs.mkShell instead.

Also add two dependencies required for some build options.

- adafruit-nrfutil
- python3.packages.pillow