### PR TITLE
envs/infinisim: add libpng12

### DIFF
--- a/envs/infinisim/README.md
+++ b/envs/infinisim/README.md
@@ -15,3 +15,5 @@ $ cmake --build build -j6
 By default the build uses a version of the [InfiniTime sources](https://github.com/InfiniTimeOrg/InfiniTime) in `./InfiniTime` as git submodule. You might want to delete this submodule and use a symlink to a local version of InfiniTime or update the submodule to track your own fork of InfiniTime.
 
 Further build instructions: https://github.com/InfiniTimeOrg/InfiniSim/blob/main/README.md
+
+This `shell.nix` works with `direnv`.

--- a/envs/infinisim/shell.nix
+++ b/envs/infinisim/shell.nix
@@ -1,6 +1,7 @@
-{ pkgs ? import <nixpkgs> {}, extraPkgs ? []
+{
+  pkgs ? import <nixpkgs> {},
+  extraPkgs ? []
 }:
-
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     cmake
@@ -9,6 +10,7 @@ pkgs.mkShell {
     libpng
     gcc12
     ccache
+    libpng12
     (python3.withPackages(python: [
       python.pillow
     ]))


### PR DESCRIPTION
The optional feature to process images for the emulated storage uses libpng12.