### PR TITLE
git: add shell environment for git.git

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ What environments should **not** include:
 | [cc2538-bsl](envs/cc2538-bsl)                   | `cc2538-bsl`          |
 | [Jruby](envs/jruby)                             | `jruby`               |
 | [Firefox](envs/firefox)                         | `firefox`             |
+| [Git](envs/git)                                 | `git`                 |
 | [Github Pages](envs/github-pages)               | `github-pages`        |
 | [Homeassistant](envs/home-assistant)            | `home-assistant`      |
 | [Nannou](envs/nannou)                           | `nannou`              |

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
   firefox = import ./envs/firefox/shell.nix { inherit pkgs; };
   infinitime = import ./envs/infinitime/shell.nix { pkgs = pkgsUnfree; };
   infinisim = import ./envs/infinisim/shell.nix { inherit pkgs; };
+  git = import ./envs/git/shell.nix { inherit pkgs; };
   github-pages = import ./envs/github-pages/shell.nix { inherit pkgs; };
   home-assistant = import ./envs/home-assistant/shell.nix { inherit pkgs; };
   jruby = import ./envs/jruby/shell.nix { inherit pkgs; };

--- a/envs/git/README.md
+++ b/envs/git/README.md
@@ -1,0 +1,23 @@
+# Git
+
+Git is a fast, scalable, distributed revision control system. See
+[Git](https://git-scm.com) for more details.
+
+This shell environment configuration allows you to build Git and its
+documentation, as well as run its tests.
+
+## Building Git
+
+Run `make` from the Git repository's root directory.
+
+## Building Git documentation
+
+Run `make` from the `Documentation` directory.
+
+## Running Git tests
+
+Run `make` from the `t` directory to kick off the full test suite.
+Alternatively, the individual test scripts can be run directly.
+
+See [t/README.md](https://github.com/git/git/blob/master/t/README) for more
+details.

--- a/envs/git/shell.nix
+++ b/envs/git/shell.nix
@@ -1,0 +1,36 @@
+{
+  pkgs ? import <nixpkgs> { },
+  extraPkgs ? [ ],
+}:
+
+with pkgs;
+mkShell {
+  nativeBuildInputs = [
+    # Building git
+    libiconv
+
+    # Building the docs
+    asciidoc
+    docbook-xsl-nons
+    docbook_xml_dtd_45
+    libxslt
+    xmlto
+  ];
+  buildInputs =
+    [
+      curl
+      expat
+      gettext
+      openssl
+      perl
+      zlib
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.CoreServices
+    ]
+    ++ extraPkgs;
+  PERL_PATH = "${perl.outPath}/bin/perl";
+  shellHook = lib.strings.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS="-F${darwin.apple_sdk.frameworks.CoreServices}/Library/Frameworks -framework CoreServices $NIX_LDFLAGS"
+  '';
+}


### PR DESCRIPTION
This `shell.nix` file provides an environment that allows building and testing git with `make`. The tools/libraries included were determined by reviewing git's `INSTALL` document [1] followed by some trial and error.

Exporting `PERL_PATH` as an environment variable allows both the build and test processes to work despite `perl` not being present at `/usr/bin/perl` on a standard NixOS install.

Tested on both `x86_64-linux` and `aarch64-darwin`.

[1]: https://github.com/git/git/blob/2e7b89e038c0c888acf61f1b4ee5a43d4dd5e94c/INSTALL#L110