### PR TITLE
envs/yocto: add missing lz4c alias for scarthgap

### DIFF
--- a/envs/infinitime/shell.nix
+++ b/envs/infinitime/shell.nix
@@ -10,12 +10,12 @@ pkgs.mkShell {
     cmake
     gcc10
     adafruit-nrfutil
+    mcuboot-imgtool
     (python3.withPackages(python: [
       python.cbor
       python.intelhex
       python.click
       python.cryptography
-      python.imgtool
       python.pillow
     ]))
     nodePackages.lv_font_conv

--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -11,6 +11,12 @@ let
           configureFlags = old.configureFlags ++ [ "--with-termlib" ];
           postFixup = "";
         });
+      lz4' = pkgs.lz4.overrideAttrs
+        (old: {
+          postInstall = ''
+            ln -rs $out/bin/lz4 $out/bin/lz4c
+          '';
+        });
     in
     (with pkgs; [
       attr
@@ -29,7 +35,7 @@ let
       hostname
       kconfig-frontends
       libxcrypt
-      lz4
+      lz4'
       # https://github.com/NixOS/nixpkgs/issues/218534
       # postFixup would create symlinks for the non-unicode version but since it breaks
       # in buildFHSUserEnv, we just install both variants


### PR DESCRIPTION
This has been default in the default poky distribution for a while, but according to https://manpages.debian.org/testing/lz4/lz4c.1.en.html, it's just an alias to `lz4`