### PR TITLE
yocto: fix for missing libcrypt.so.1.

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -36,6 +36,7 @@ let
       hostname
       kconfig-frontends
       libxcrypt
+      libxcrypt-legacy
       lz4'
       # https://github.com/NixOS/nixpkgs/issues/218534
       # postFixup would create symlinks for the non-unicode version but since it breaks


### PR DESCRIPTION
I did bump into this issue w/ NixOS 24.11. 