### PR TITLE
openwrt: fix gcc-{ar,nm,ranlib} symlinks

### DIFF
--- a/envs/openwrt/shell.nix
+++ b/envs/openwrt/shell.nix
@@ -11,6 +11,7 @@ let
     for i in ${pkgs.gcc.cc}/bin/*-gnu-{g++,c++}*; do
       ln -s ${pkgs.gcc}/bin/g++ $out/bin/$(basename "$i")
     done
+    ln -sf ${pkgs.gcc.cc}/bin/{,*-gnu-}gcc-{ar,nm,ranlib} $out/bin
   '';
 
   fhs = pkgs.buildFHSUserEnv {


### PR DESCRIPTION
These should absoluetly not point to the gcc wrapper, they are thin wrappers around the binutils tools that are necessary to make LTO work.

This fix link failures in apk, where Meson would (I assume) see a broken x86_64-unknown-linux-gnu-gcc-ar (or a missing gcc-ar), and fall back to the unwrapped ar.