### PR TITLE
fix: rename buildFHSUserEnv to buildFHSEnv, fixing warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ nix-shell https://github.com/nix-community/nix-environments/archive/master.tar
 ```
 
 To apply custom modification one can also import environments into their own `shell.nix` files and
-override them. Note that this approach does currently not work for buildFHSUserEnv-based environments!
+override them. Note that this approach does currently not work for buildFHSEnv-based environments!
 
 ```nix
 { pkgs ? import <nixpkgs> {} }:
@@ -68,7 +68,7 @@ in (phoronix.overrideAttrs (old: {
 }))
 ```
 
-To provide additional packages to buildFHSUserEnv-based environments you can use the `extraPkgs` attribute and `import` 
+To provide additional packages to buildFHSEnv-based environments you can use the `extraPkgs` attribute and `import` 
 the shell file directly:
 
 ```nix

--- a/envs/arduino/README.md
+++ b/envs/arduino/README.md
@@ -1,8 +1,8 @@
-## buildFHSUserEnv for Arduino IDE 
+## buildFHSEnv for Arduino IDE 
 
 Arduino will also download additional binaries into the users home.
 That's why we need to use a sandbox created by:
-[buildFHSUserEnv](https://nixos.org/nixpkgs/manual/#sec-fhs-environments)
+[buildFHSEnv](https://nixos.org/nixpkgs/manual/#sec-fhs-environments)
 to avoid the use of [patchelf](https://nixos.org/patchelf.html).
 
 The environment was only tested with an ESP32. It might be that

--- a/envs/arduino/shell.nix
+++ b/envs/arduino/shell.nix
@@ -2,7 +2,7 @@
 , extraPkgs ? []
 }:
 
-(pkgs.buildFHSUserEnv {
+(pkgs.buildFHSEnv {
   name = "arduino-env";
   targetPkgs = pkgs: with pkgs; [
     ncurses

--- a/envs/buildroot/README.md
+++ b/envs/buildroot/README.md
@@ -12,4 +12,4 @@ For more info checkout [buildroot over on GitLab](https://gitlab.com/buildroot.o
 - Some dependencies are not mentioned in the docs (yet) - they were found by trial and error
 - At the time of writing buildroot under nixos suffers from incompatibility between their systemd version and nixos's kernel headers
   A patch from the mailing list has to be applied: https://lore.kernel.org/all/20240515144432.3152351-1-bruce.ashfield@gmail.com/T/
-- buildFHSUserEnv is required as buildroot tooling has some hardcoded paths expecting a "usual" linux FS
+- buildFHSEnv is required as buildroot tooling has some hardcoded paths expecting a "usual" linux FS

--- a/envs/buildroot/shell.nix
+++ b/envs/buildroot/shell.nix
@@ -38,7 +38,7 @@ in
   # Unfortunately the more versatile and nix-nativ mkShell does not work
   # for buildroot as some of the paths are hardcoded and expect a usual
   # linux posix-compliant file system structure
-  (pkgs.buildFHSUserEnv {
+  (pkgs.buildFHSEnv {
     name = "buildroot";
     targetPkgs = pkgs: (with pkgs; [
       (lib.hiPrio gcc)

--- a/envs/openwrt/shell.nix
+++ b/envs/openwrt/shell.nix
@@ -14,7 +14,7 @@ let
     ln -sf ${pkgs.gcc.cc}/bin/{,*-gnu-}gcc-{ar,nm,ranlib} $out/bin
   '';
 
-  fhs = pkgs.buildFHSUserEnv {
+  fhs = pkgs.buildFHSEnv {
     name = "openwrt-env";
     targetPkgs = pkgs: with pkgs; [
       binutils

--- a/envs/spec-benchmark/shell.nix
+++ b/envs/spec-benchmark/shell.nix
@@ -16,7 +16,7 @@ let
     done
   '';
 
-  fhs = pkgs.buildFHSUserEnv {
+  fhs = pkgs.buildFHSEnv {
     name = "spec-env";
     targetPkgs = pkgs: with pkgs; [
       # higher priority then the default gcc

--- a/envs/xilinx-vitis/shell.nix
+++ b/envs/xilinx-vitis/shell.nix
@@ -4,7 +4,7 @@
 , xilinxName ? "xilinx-env"
 }:
 
-(pkgs.buildFHSUserEnv {
+(pkgs.buildFHSEnv {
   name = xilinxName;
   inherit runScript;
   targetPkgs = pkgs: with pkgs; let
@@ -21,7 +21,7 @@
     stdenv.cc.cc
     # https://github.com/NixOS/nixpkgs/issues/218534
     # postFixup would create symlinks for the non-unicode version but since it breaks
-    # in buildFHSUserEnv, we just install both variants
+    # in buildFHSEnv, we just install both variants
     ncurses'
     (ncurses'.override { unicodeSupport = false; })
     xorg.libXext


### PR DESCRIPTION
This is to fix the warning:
```
evaluation warning: 'buildFHSUserEnv' has been renamed to 'buildFHSEnv' and will be removed in 25.11
```

Just did a sed find and replace with command `sed -i "s/buildFHSUserEnv/buildFHSEnv/g" ./**/*.md ./**/*.nix`

`nix flake check` reports no issues, and every shell can be be built and entered correctly.

Tested the building and entering using 
```nu
 for shell in (ls ./envs/* -s | where type == 'dir' | get name) 
 {
 print $'Building env for ($shell)'; nix-shell -A ($shell);
 }
```

Have not re verified the functionality of the shells.