### PR TITLE
yocto: add python websockets package

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -45,7 +45,7 @@ let
       (ncurses'.override { unicodeSupport = false; })
       patch
       perl
-      (python3.withPackages (ps: [ ps.setuptools ps.pyaml ] ++ extraPythonPkgs))
+      (python3.withPackages (ps: [ ps.setuptools ps.pyaml ps.websockets ] ++ extraPythonPkgs))
       rpcsvc-proto
       unzip
       util-linux


### PR DESCRIPTION
This is required if the upstream sstate server should be used, as shown in
https://docs.yoctoproject.org/singleindex.html#building-your-image