### PR TITLE
Remove setuptools from Home Assistant

### DIFF
--- a/envs/home-assistant/shell.nix
+++ b/envs/home-assistant/shell.nix
@@ -7,7 +7,6 @@ pkgs.mkShell {
     bashInteractive
     pkg-config
     autoreconfHook
-    python313.pkgs.setuptools
     python313
     libjpeg
     libxslt


### PR DESCRIPTION
This was causing issues because it was using an old setuptools version.
Apparently setuptools does not need to be pulled from nixpkgs now for
HA.
