### PR TITLE
ladybird: fix typo in build instructions

### DIFF
--- a/envs/ladybird/README.md
+++ b/envs/ladybird/README.md
@@ -13,7 +13,7 @@ Clone the repository & enter the shell:
 
 ```
 git clone https://github.com/LadybirdBrowser/ladybird
-nix develop
+nix develop --no-write-lock-file github:nix-community/nix-environments#ladybird
 ```
 
 First invoke `cmake` directly. For example:


### PR DESCRIPTION
Copy and paste error from the old ladybird docs oopsie