### PR TITLE
env/yocto: Add openssh

### DIFF
--- a/envs/yocto/shell.nix
+++ b/envs/yocto/shell.nix
@@ -44,6 +44,7 @@ let
       # in buildFHSEnv, we just install both variants
       ncurses'
       (ncurses'.override { unicodeSupport = false; })
+      openssh
       patch
       perl
       (python3.withPackages (ps: [ ps.setuptools ps.pyaml ps.websockets ] ++ extraPythonPkgs))


### PR DESCRIPTION
Fix parsing of yocto recepies that use SSH in SRC_URI

Let me preface this PR with the fact that I am new to nix, and i'm not an expert on yocto. 
So my solution or original problem might be "wrong", but I hope my fix is acceptable.
At work i have some precipices that use ssh protocol for SRC_URI and they failed parsing until I added openssh to the nix env.

Here is an abbreviated error I had
git -c gc.autoDetach=false -c core.pager=cat -c safe.bareRepository=all ls-remote ssh://git@bitbucket-ssh.dev......  failed with exit code 128, output:
error: cannot run ssh: No such file or directory
fatal: unable to fork