### PR TITLE
ladybird: document disabling LTO

### DIFF
--- a/envs/ladybird/README.md
+++ b/envs/ladybird/README.md
@@ -16,9 +16,12 @@ git clone https://github.com/LadybirdBrowser/ladybird
 nix develop --no-write-lock-file github:nix-community/nix-environments#ladybird
 ```
 
+Note that if the build fails due to the process lto1-wpt using too much memory, the `ENABLE_LTO_FOR_RELEASE` option should be turned off.
+
 First invoke `cmake` directly. For example:
 
  - `cmake -GNinja -BBuild/release`
+ - `cmake -DENABLE_LTO_FOR_RELEASE=OFF -GNinja -BBuild/release`
  - `cmake -DCMAKE_BUILD_TYPE=Debug -GNinja -BBuild/debug`
  - `cmake -DENABLE_LAGOM_CCACHE=True -GNinja -BBuild/debug`
  - With sanitizers:


### PR DESCRIPTION
While attempting to build ladybird at the same 2025-12-03 commit as nixpkgs, encountered repeated issues with process lto1-wpt using so much memory that 32GB RAM is not enough.

Turning off LTO makes the build succeed using low ram.

Disabling LTO is mentioned in the ladybird nixpkgs package.

```
  cmakeFlags = [
    # Takes an enormous amount of resources, even with mold
    (lib.cmakeBool "ENABLE_LTO_FOR_RELEASE" false)
    # Disable network operations
    "-DLADYBIRD_CACHE_DIR=Caches"
    "-DENABLE_NETWORK_DOWNLOADS=OFF"
  ]

```