### PR TITLE
Remove usage of `nodePackages`

### DIFF
--- a/envs/infinisim/shell.nix
+++ b/envs/infinisim/shell.nix
@@ -14,6 +14,6 @@ pkgs.mkShell {
     (python3.withPackages(python: [
       python.pillow
     ]))
-    nodePackages.lv_font_conv
+    lv_font_conv
   ] ++ extraPkgs;
 }

--- a/envs/ladybird/shell.nix
+++ b/envs/ladybird/shell.nix
@@ -19,7 +19,7 @@ pkgs.mkShell {
   packages = with pkgs; [
     ccache
     clang-tools
-    nodePackages.prettier
+    prettier
     icu78
   ] ++ extraPkgs;
 


### PR DESCRIPTION
- `nodePackages` were removed from nixpkgs, making the shell not longer evaluating