### PR TITLE
ladybird: add mimalloc

### DIFF
--- a/envs/ladybird/shell.nix
+++ b/envs/ladybird/shell.nix
@@ -21,6 +21,7 @@ pkgs.mkShell {
     clang-tools
     prettier
     icu78
+    mimalloc
   ] ++ extraPkgs;
 
   # https://github.com/NixOS/nixpkgs/blob/79a8a723b9/pkgs/by-name/la/ladybird/package.nix#L144-L147


### PR DESCRIPTION
Closes #132

Ladybird cmake was failing with:
```
✦ › : nix develop --no-write-lock-file github:nix-community/nix-environments#ladybird
warning: not writing modified lock file of flake 'github:nix-community/nix-environments':
• Added input 'nixpkgs':
    'path:/nix/store/wjfxdzblindbl9sp2hbwhi4iyh5jh348-source?lastModified=1777578337&narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D&rev=15f4ee454b1dce334612fa6843b3e05cf546efab' (2026-04-30)
✦ › : cmake -DCMAKE_BUILD_TYPE=Debug -GNinja -BBuild/debug
CMake Error at Meta/CMake/check_for_dependencies.cmake:5 (find_package):
  Could not find a package configuration file provided by "mimalloc" with any
  of the following names:
    mimallocConfig.cmake
    mimalloc-config.cmake
  Add the installation prefix of "mimalloc" to CMAKE_PREFIX_PATH or set
  "mimalloc_DIR" to a directory containing one of the above files.  If
  "mimalloc" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:54 (include)
-- Configuring incomplete, errors occurred!
```
