### PR TITLE
openwrt: update shell.nix for OpenWrt 25.x

### DIFF
--- a/envs/openwrt/shell.nix
+++ b/envs/openwrt/shell.nix
@@ -1,50 +1,63 @@
 { pkgs ? import <nixpkgs> {}
 , extraPkgs ? []
 }:
-
 let
-  fixWrapper = pkgs.runCommand "fix-wrapper" {} ''
-    mkdir -p $out/bin
-    for i in ${pkgs.gcc.cc}/bin/*-gnu-gcc*; do
-      ln -s ${pkgs.gcc}/bin/gcc $out/bin/$(basename "$i")
-    done
-    for i in ${pkgs.gcc.cc}/bin/*-gnu-{g++,c++}*; do
-      ln -s ${pkgs.gcc}/bin/g++ $out/bin/$(basename "$i")
-    done
-    ln -sf ${pkgs.gcc.cc}/bin/{,*-gnu-}gcc-{ar,nm,ranlib} $out/bin
-  '';
-
   fhs = pkgs.buildFHSEnv {
     name = "openwrt-env";
-    targetPkgs = pkgs: with pkgs; [
+    targetPkgs = p: with p; [
+      bash
+      bc
       binutils
+      bison
+      bzip2
+      coreutils
+      diffutils
       file
-      fixWrapper
+      findutils
+      flex
+      gawk
       gcc
+      # Meson (detect_static_linker) prefers gcc-ar over ar when GCC + b_lto=true.
+      # gcc-ar automatically loads liblto_plugin.so so libapk.a gets a proper LTO
+      # symbol index. Without these, Meson falls back to bare ar and apk fails to
+      # link (undefined reference to apk_blob_hash etc.).
+      (pkgs.runCommand "gcc-lto-tools" {} ''
+        mkdir -p $out/bin
+        ln -s ${pkgs.gcc.cc}/bin/gcc-ar      $out/bin/gcc-ar
+        ln -s ${pkgs.gcc.cc}/bin/gcc-ranlib  $out/bin/gcc-ranlib
+        ln -s ${pkgs.gcc.cc}/bin/gcc-nm      $out/bin/gcc-nm
+      '')
+      gettext
       git
+      glibc           # dev output provides /usr/include (sys/types.h, argp.h, fts.h)
       glibc.static
       gnumake
+      gnugrep
+      gnused
+      gnutar
+      gzip
+      libxslt         # xsltproc
       ncurses
       openssl
       patch
       perl
       pkg-config
       (python3.withPackages (ps: [ ps.setuptools ]))
+      quilt
       rsync
-      subversion
       swig
-      systemd
       unzip
-      util-linux
+      util-linux      # getopt --long, checked by prereq-build.mk
       wget
       which
+      xz
       zlib
-      zlib.static
     ] ++ extraPkgs;
-    multiPkgs = null;
     extraOutputsToInstall = [ "dev" ];
-    profile = ''
-      export hardeningDisable=all
-    '';
+    hardeningDisable = [ "all" ];
+    # FAKEROOTDONTTRYCHOWN must be set via extraBwrapArgs (--setenv) so it is
+    # present inside the bwrap sandbox itself. Inside Bubblewrap, chown returns
+    # EINVAL instead of the EPERM fakeroot expects, which aborts package/install.
+    extraBwrapArgs = [ "--setenv" "FAKEROOTDONTTRYCHOWN" "1" ];
   };
 in fhs


### PR DESCRIPTION
Updates the OpenWrt environment for current OpenWrt main (25.x).

The package list was reworked against prereq-build.mk and verified with a full `make -j$(nproc)` build (x86_64 and aarch64). Removed the old fixWrapper, subversion and systemd; added the packages a full source build actually needs.

gcc-lto-tools: apk is built with Meson + LTO, and Meson falls back to bare `ar` unless `gcc-ar`/`gcc-nm`/`gcc-ranlib` are on PATH, which breaks the link (undefined reference to apk_blob_hash). Exposing the gcc-* wrappers fixes it.

extraOutputsToInstall = ["dev"]: pulls in glibc headers (sys/types.h etc.), which the toolchain build needs. Replaces the old fixWrapper hack.

FAKEROOTDONTTRYCHOWN=1 via extraBwrapArgs: inside bwrap, chown returns EINVAL instead of EPERM, which fakeroot doesn't catch and package/install fails.

multiPkgs is dropped since LuaJIT (the only 32-bit host dependency) is gone.

apk/fakeroot/mksquashfs4 aren't in the FHS but the ImageBuilder ships them self-contained, so no extra packages are needed.

Verified against OpenWrt 25.12.4: full source build (buildroot, x86_64 + aarch64) and ImageBuilder (mvebu/cortexa72, RB5009) including PACKAGES and FILES.