### PR TITLE
ladybird: fix shell.nix for current nixpkgs and NixOS 26.05

### DIFF
--- a/envs/ladybird/README.md
+++ b/envs/ladybird/README.md
@@ -6,8 +6,13 @@
 
 Ladybird's build system uses vcpkg to vendor third-party dependencies, which proves undesirable to
 use with Nix for [several reasons](https://github.com/LadybirdBrowser/ladybird/issues/371).
-As a result, using `ladybird.sh` to compile and run Ladybird will fail. Therefore, it is necessary
+As a result, using `ladybird.py` to compile and run Ladybird will fail. Therefore, it is necessary
 to use system packages provided by this environment.
+
+This environment exports `ICU_ROOT` and sets `FONTCONFIG_FILE` (pointing to `dejavu_fonts` and
+`liberation_ttf`). Both are required: without `ICU_ROOT` cmake cannot locate ICU headers, and
+without the font configuration Ladybird crashes with `SIGILL` on startup because its font
+fallback lists require fonts not present in a default NixOS installation.
 
 Clone the repository & enter the shell:
 

--- a/envs/ladybird/shell.nix
+++ b/envs/ladybird/shell.nix
@@ -7,22 +7,25 @@ pkgs.mkShell {
   name = "ladybird-env";
 
   inputsFrom = [
-    (pkgs.ladybird.override (prev: {
-      skia = prev.skia.overrideAttrs (prev: {
-        gnFlags = prev.gnFlags ++ [
-          "extra_cflags_cc=[\"-frtti\"]"
-        ];
-      });
-    }))
+    pkgs.ladybird
   ];
 
   packages = with pkgs; [
     ccache
     clang-tools
     prettier
-    icu78
+    icu78.dev
+    mimalloc
+    dejavu_fonts
+    liberation_ttf
   ] ++ extraPkgs;
 
+  ICU_ROOT = "${pkgs.icu78.dev}";
+
+  FONTCONFIG_FILE = pkgs.makeFontsConf {
+    fontDirectories = [ pkgs.dejavu_fonts pkgs.liberation_ttf ];
+  };
+
   # https://github.com/NixOS/nixpkgs/blob/79a8a723b9/pkgs/by-name/la/ladybird/package.nix#L144-L147
-  NIX_LDFLAGS = "-lGL";
+  NIX_LDFLAGS = "-lGL -lfontconfig";
 }


### PR DESCRIPTION
The existing shell.nix had several issues that prevented a successful build on current nixpkgs (NixOS 26.05, clang 21.1.8).

The Skia override using -frtti is already integrated into nixpkgs package.nix since 2025. Having an additional incomplete override in the devShell caused the build to fail with an AVX/ABI error in SkVx.h. Removing the override and using pkgs.ladybird directly via inputsFrom fixes this.

mimalloc was missing from packages. Ladybird HEAD requires it via find_package(mimalloc CONFIG REQUIRED) and cmake fails without it. This also closes #132. Similarly, libedit and other dependencies were missing because the incomplete Skia override prevented pkgs.ladybird's full dependency tree from being pulled in automatically. Switching to plain inputsFrom = [ pkgs.ladybird ] resolves this, closing #137.

icu78 was listed instead of icu78.dev. cmake needs the headers from the .dev output to find ICU. ICU_ROOT is now exported so cmake finds it without manual flags.

Without dejavu_fonts and liberation_ttf, Ladybird crashes immediately on start with a SIGILL due to null font fallbacks in FontPlugin.cpp and StyleComputer.cpp. FONTCONFIG_FILE is set explicitly because nix-shell does not wire up fontconfig automatically for shell packages.

-lfontconfig was missing from NIX_LDFLAGS, matching the existing comment in nixpkgs package.nix.

Tested with nixpkgs ladybird.src.rev 90b790f8 and Ladybird HEAD 340d87ef on NixOS 26.05. Closes #132. Closes #137.